### PR TITLE
Implement Private pins

### DIFF
--- a/src/data/DataConverters.ts
+++ b/src/data/DataConverters.ts
@@ -150,6 +150,7 @@ const pinConverter = {
       reviews: pinReviewsConverter.toFirestore(pin.reviews),
       photos: pinPhotosConverter.toFirestore(pin.photos),
       activity: pinActivityConverter.toFirestore(pin.activity),
+      privateViewers: pin.privateViewers,
     };
   },
   fromFirestore: (snapshot: QueryDocumentSnapshot) => {
@@ -159,17 +160,15 @@ const pinConverter = {
       pinDetailsConverter.fromFirestore(snapshot),
       pinReviewsConverter.fromFirestore(snapshot),
       pinPhotosConverter.fromFirestore(snapshot),
-      pinActivityConverter.fromFirestore(snapshot)
+      pinActivityConverter.fromFirestore(snapshot),
+      snapshot.get("privateViewers") || []
     );
   },
 };
 
 const userConverter = {
   fromFirestore: (snapshot: QueryDocumentSnapshot) => {
-    return new User(
-      snapshot.get('userID'),
-      snapshot.get('checkInSpot')
-    );
+    return new User(snapshot.get("userID"), snapshot.get("checkInSpot"));
   },
 };
 
@@ -180,5 +179,5 @@ export {
   pinReviewsConverter,
   pinPhotosConverter,
   pinActivityConverter,
-  userConverter
+  userConverter,
 };

--- a/src/data/Interfaces.ts
+++ b/src/data/Interfaces.ts
@@ -1,5 +1,4 @@
 import { LatLng } from "react-native-maps";
-import { User } from "./User";
 
 interface IPin {
   key: number;
@@ -8,6 +7,7 @@ interface IPin {
   reviews: IPinReview[];
   photos: IPinPhoto[];
   activity: IPinActivity;
+  privateViewers: string[];
 }
 
 interface IPinDetails {
@@ -49,7 +49,7 @@ interface IUser {
 interface IDatabase {
   addUser(user: IUser): void;
 
-  getUser(userID: string): Promise<IUserActionResult<IUser>>
+  getUser(userID: string): Promise<IUserActionResult<IUser>>;
 
   ChangeCheckInSpot(userID: string, newCheckInSpot: number): void;
 

--- a/src/data/Pin.ts
+++ b/src/data/Pin.ts
@@ -14,6 +14,7 @@ class Pin implements IPin {
   reviews: IPinReview[];
   photos: IPinPhoto[];
   activity: IPinActivity;
+  privateViewers: string[];
 
   constructor(
     key: number,
@@ -21,7 +22,8 @@ class Pin implements IPin {
     details: PinDetails,
     reviews: PinReview[],
     photos: IPinPhoto[],
-    activity: PinActivity
+    activity: PinActivity,
+    privateViewers: string[] = []
   ) {
     this.key = key;
     this.coordinate = coordinate;
@@ -29,6 +31,7 @@ class Pin implements IPin {
     this.reviews = reviews;
     this.photos = photos;
     this.activity = activity;
+    this.privateViewers = privateViewers;
   }
 
   toString(): string {
@@ -142,7 +145,11 @@ class PinActivity implements IPinActivity {
   activeUsers: number;
   totalUsers: number;
 
-  constructor(shareableSlackline: boolean, activeUsers: number, totalUsers: number) {
+  constructor(
+    shareableSlackline: boolean,
+    activeUsers: number,
+    totalUsers: number
+  ) {
     this.shareableSlackline = shareableSlackline;
     this.activeUsers = activeUsers;
     this.totalUsers = totalUsers;

--- a/src/redux/PinSlice.ts
+++ b/src/redux/PinSlice.ts
@@ -25,8 +25,8 @@ const examplePin1: Pin = {
   activity: {
     shareableSlackline: false,
     activeUsers: 0,
-    totalUsers:  0,
-  }
+    totalUsers: 0,
+  },
 };
 
 const examplePin2: Pin = {
@@ -34,7 +34,7 @@ const examplePin2: Pin = {
   coordinate: {
     latitude: 48.459405,
     longitude: -123.327318,
-  }, 
+  },
   details: {
     title: "Mt Tomie",
     description: "Its pretty cool, nice views.",
@@ -48,8 +48,8 @@ const examplePin2: Pin = {
   activity: {
     shareableSlackline: false,
     activeUsers: 0,
-    totalUsers:  0,
-  }
+    totalUsers: 0,
+  },
 };
 
 export interface PinsState {
@@ -65,9 +65,9 @@ export const pinSlice = createSlice({
   initialState,
   reducers: {
     addPin: (state, action: PayloadAction<Pin>) => {
-        if(!state.pins.find((pin) => pin.key == action.payload.key)) {
-            state.pins.push(action.payload);
-        }
+      if (!state.pins.find((pin) => pin.key == action.payload.key)) {
+        state.pins.push(action.payload);
+      }
     },
     updatePin: (state, action: PayloadAction<Pin>) => {
       state.pins = state.pins.map((pin) => {
@@ -85,7 +85,8 @@ export const pinSlice = createSlice({
             },
             reviews: action.payload.reviews,
             photos: action.payload.photos,
-            activity: action.payload.activity
+            activity: action.payload.activity,
+            privateViewers: action.payload.privateViewers,
           };
         }
         return pin;

--- a/src/screens/Map/MapScreen.tsx
+++ b/src/screens/Map/MapScreen.tsx
@@ -59,9 +59,6 @@ let newPin: Pin = {
   privateViewers: [],
 };
 
-const defaultColor: string = "#219f94";
-const hotColor: string = "#D2042D";
-
 export const MapScreen = ({ route, navigation }: any) => {
   const pins = useSelector((state: RootState) => state.pins.pins);
   const dispatch = useDispatch();

--- a/src/screens/Map/MapScreen.tsx
+++ b/src/screens/Map/MapScreen.tsx
@@ -12,7 +12,12 @@ import {
   updatePin,
 } from "../../redux/PinSlice";
 import { Pin } from "../../data/Pin";
-import { collection, getFirestore, onSnapshot, query } from "@firebase/firestore";
+import {
+  collection,
+  getFirestore,
+  onSnapshot,
+  query,
+} from "@firebase/firestore";
 import { auth, firebaseApp } from "../../config/FirebaseConfig";
 import { Database } from "../../data/Database";
 import { pinConverter } from "../../data/DataConverters";
@@ -50,10 +55,11 @@ let newPin: Pin = {
     activeUsers: 0,
     totalUsers: 0,
   },
+  privateViewers: [],
 };
 
-const defaultColor:string = "#219f94";
-const hotColor:string = "#D2042D";
+const defaultColor: string = "#219f94";
+const hotColor: string = "#D2042D";
 
 export const MapScreen = ({ route, navigation }: any) => {
   const pins = useSelector((state: RootState) => state.pins.pins);
@@ -69,16 +75,13 @@ export const MapScreen = ({ route, navigation }: any) => {
   const db = getFirestore(firebaseApp);
   const q = query(collection(db, "pins"));
 
-
   // navigate to login screen if user is not logged in
-  useEffect( () => {
+  useEffect(() => {
     const user = auth.currentUser;
-    console.log(`user in map: ${user}`);
-    if(!user) {
-        console.log(`should navigate to login`);
-        navigation.navigate("Login");
+    if (!user) {
+      navigation.navigate("Login");
     }
-  }, [])
+  }, []);
 
   useEffect(() => {
     const unsubscribe = onSnapshot(q, (snapshot) => {
@@ -99,7 +102,7 @@ export const MapScreen = ({ route, navigation }: any) => {
   useEffect(() => {
     if (route.params?.confirmedPin) {
       setAddPinVisible(true);
-      setHotSpotToggleVisible(true)
+      setHotSpotToggleVisible(true);
       setConfirmCancelVisible(false);
       route.params.confirmedPin = false;
     }
@@ -109,10 +112,10 @@ export const MapScreen = ({ route, navigation }: any) => {
   // button is red -> only pins with people currently checked in
   // button is aqua -> all pins
   const handleHotspotToggle = () => {
-    let newColor:string = defaultColor;
-    if(hotspotToggleColor == defaultColor) newColor = hotColor;
+    let newColor: string = defaultColor;
+    if (hotspotToggleColor == defaultColor) newColor = hotColor;
     setHotspotToggleColor(newColor);
-  }
+  };
 
   // Keeps track of the map region
   const updateRegionCoordinates = (e: LatLng) => {
@@ -207,13 +210,26 @@ export const MapScreen = ({ route, navigation }: any) => {
 
   const onMapPress = () => {
     setPinInfoVisible(false);
-    setSelectedPin(null)
+    setSelectedPin(null);
     setHotSpotToggleVisible(true);
     setAddPinVisible(true);
-  }
+  };
 
-  let pinsToRender = pins;
-  if (hotspotToggleColor == hotColor) pinsToRender = pins.filter(pin => pin.activity.activeUsers > 0);
+  // Filter out any pins that shouldn't be visible to the current user
+  // this means any pins that were created as private by other people
+  // that the current user does not have permission to view
+  // keeps any publicly available pins as well as any private
+  // pins the user has permission to view
+
+  let pinsToRender: Pin[] = pins.filter(
+    (pin: Pin) =>
+      pin.privateViewers?.length == 0 ||
+      !pin.privateViewers ||
+      pin.privateViewers.indexOf(auth.currentUser?.uid || "") > -1
+  );
+
+  if (hotspotToggleColor == hotColor)
+    pinsToRender = pinsToRender.filter((pin) => pin.activity.activeUsers > 0);
 
   return (
     <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
@@ -236,7 +252,11 @@ export const MapScreen = ({ route, navigation }: any) => {
             key={pin.key}
             coordinate={pin.coordinate}
             pinColor={pin.details.color}
-            image={pin.activity.activeUsers ? require("../../assets/flame1.png") : null}
+            image={
+              pin.activity.activeUsers
+                ? require("../../assets/flame1.png")
+                : null
+            }
             draggable={pin.details.draggable}
             onDragEnd={(e) => updateNewPinCoordinates(e.nativeEvent.coordinate)}
             onPress={(e) => {
@@ -256,9 +276,9 @@ export const MapScreen = ({ route, navigation }: any) => {
       ) : null}
       {confirmCancelVisible ? (
         <FAB
-          titleStyle={{ color: defaultColor}}
+          titleStyle={{ color: defaultColor }}
           title="Cancel"
-          icon={{ name: "close", color: defaultColor}}
+          icon={{ name: "close", color: defaultColor }}
           color="white"
           onPress={handleCancelPress}
           placement="left"
@@ -266,21 +286,21 @@ export const MapScreen = ({ route, navigation }: any) => {
       ) : null}
       {addPinVisible ? (
         <>
-        {hotspotToggleVisible? (
+          {hotspotToggleVisible ? (
+            <FAB
+              icon={{ name: "whatshot", color: "white" }}
+              style={{ paddingBottom: 65 }} // ensure the button doesn't overlap with the one below it
+              color={hotspotToggleColor}
+              onPress={handleHotspotToggle}
+              placement="right"
+            />
+          ) : null}
           <FAB
-            icon={{ name: "whatshot", color: "white" }}
-            style={{ paddingBottom: 65 }} // ensure the button doesn't overlap with the one below it
-            color={hotspotToggleColor}
-            onPress={handleHotspotToggle}
+            icon={{ name: "add", color: "white" }}
+            color={defaultColor}
+            onPress={handleAddPin}
             placement="right"
           />
-        ) : null}
-        <FAB
-          icon={{ name: "add", color: "white" }}
-          color={defaultColor}
-          onPress={handleAddPin}
-          placement="right"
-        />
         </>
       ) : null}
       {pinInfoVisible ? (
@@ -303,5 +323,5 @@ const styles = StyleSheet.create({
   },
   map: {
     ...StyleSheet.absoluteFillObject,
-  }
+  },
 });

--- a/src/screens/Map/PinDetailsScreen.tsx
+++ b/src/screens/Map/PinDetailsScreen.tsx
@@ -129,13 +129,6 @@ export const PinDetailsScreen = ({ route, navigation }) => {
             value={isPrivate}
           />
         </View>
-        <FAB
-          containerStyle={{ margin: 20 }}
-          visible={true}
-          icon={{ name: "check", color: "white" }}
-          color="#219f94"
-          title="Confirm"
-        />
         <Button
           title="Submit"
           buttonStyle={{

--- a/src/screens/Map/PinDetailsScreen.tsx
+++ b/src/screens/Map/PinDetailsScreen.tsx
@@ -5,12 +5,13 @@ import {
   TouchableWithoutFeedback,
   Keyboard,
 } from "react-native";
-import { Text, Input, FAB } from "react-native-elements";
+import { Text, Input, FAB, Switch } from "react-native-elements";
 import { useDispatch } from "react-redux";
 import { removePin } from "../../redux/PinSlice";
 import { Pin } from "../../data/Pin";
 import { Database } from "../../data/Database";
 import { pinConverter } from "../../data/DataConverters";
+import { auth } from "../../config/FirebaseConfig";
 
 const database = new Database();
 
@@ -22,14 +23,20 @@ export const PinDetailsScreen = ({ route, navigation }) => {
   const [description, onChangeDescription] = useState("");
   const [slacklineLength, onChangeLength] = useState("");
   const [slacklineType, onChangeType] = useState("");
+  const [isPrivate, setIsPrivate] = useState(false);
+
+  const togglePrivate = () => {
+    setIsPrivate((previousState) => !previousState);
+  };
 
   const onConfirmPress = async () => {
+    const userId = auth.currentUser?.uid || 0;
     const confirmPin: Pin = {
       key: newPin.key,
       coordinate: newPin.coordinate,
       details: {
         draggable: false,
-        color: "red",
+        color: isPrivate ? "green" : "red",
         title: name,
         description: description,
         slacklineType: slacklineType,
@@ -42,6 +49,11 @@ export const PinDetailsScreen = ({ route, navigation }) => {
         activeUsers: 0,
         totalUsers: 0,
       },
+      privateViewers: isPrivate
+        ? userId
+          ? [userId]
+          : ([] as string[])
+        : ([] as string[]),
     };
     dispatch(removePin(confirmPin));
     navigation.navigate({
@@ -64,7 +76,6 @@ export const PinDetailsScreen = ({ route, navigation }) => {
         <Text style={styles.text} h4>
           Add Information
         </Text>
-
         <Input
           style={styles.input}
           placeholder="Name"
@@ -90,6 +101,21 @@ export const PinDetailsScreen = ({ route, navigation }) => {
           value={slacklineLength}
           keyboardType="number-pad"
         />
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+          }}
+        >
+          <Text>Is this a private pin?</Text>
+          <Switch
+            trackColor={{ false: "#767577", true: "#219f94" }}
+            thumbColor={"#f4f3f4"}
+            ios_backgroundColor="#3e3e3e"
+            onValueChange={togglePrivate}
+            value={isPrivate}
+          />
+        </View>
         <FAB
           containerStyle={{ margin: 20 }}
           visible={true}


### PR DESCRIPTION
When a user creates a new pin, a new switch button will allow them to indicate whether or not the pin should be private. Currently the behavior is implemented in such a way that the pin's creator as well as any future friends will be able to see the pin, should the creator of the pin choose to invite them to have permission to see it.

New private pins will be rendered in green opposed to red.
If a user checks into a private pin, the old fire emoji pin will still be rendered, changing the pin's color back to green. Another ticket should probably be raised to allow for changing the color of the check in image.

Closes #33 